### PR TITLE
Must build the avatar url from data

### DIFF
--- a/src/components/AppNavbar.js
+++ b/src/components/AppNavbar.js
@@ -49,9 +49,7 @@ class AppNavbar extends Component {
               ? (
                 <UportAvatar
                   alt='user-img'
-                  src={
-                    'https://ipfs.infura.io' +
-                    this.props.uport.image.contentUrl} />
+                  src={"data:image/jpg;base64,"+ this.props.uport.avatar.data} />
               )
               : null
           }


### PR DESCRIPTION
In the current interaction with the uPort system, the system returns a data string (base64) with the image. This change will build an url from that data assuming jpg data.